### PR TITLE
Allow docker-compose up args to be overridden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Copy the script dockerservice to `/etc/init.d/dockerservice`. Each docker-compos
 The directory containing the service directories can be overridden by setting the variable `SUBCFGDIR`.  This can be set for a specific service in its `/etc/conf.d/dockerservice.$SERVICENAME` file, or the default may be changed by setting it in `/etc/rc.conf` or an `/etc/rc.conf.d` file.
 
 Alternatively, the complete path to the docker-compose input file may be specified by setting SUBCFG in the services's `/etc/rc.conf.d` file.  The value of this variable is passed to the `-f` option of `docker-compose`.
+
+By default, the `docker-compose up` command is passed the arguments `-d --no-recreate --no-build --no-deps`.  `-d` is required because that's what puts the containers in the background, but the remaining arguments may be overridden by setting `DOCKER_COMPOSE_UP_ARGS`.

--- a/dockerservice
+++ b/dockerservice
@@ -1,6 +1,7 @@
 #!/sbin/openrc-run
 
 : ${SUBCFGDIR:=/root/docker}
+DOCKER_COMPOSE_UP_ARGS=${DOCKER_COMPOSE_UP_ARGS-"--no-build --no-recreate --no-deps"}
 
 SUBSVC="${SVCNAME#*.}"
 [ -z "${SUBSVC}" ] && exit 1
@@ -30,7 +31,7 @@ configtest() {
 start() {
   configtest || return 1
   ebegin "Starting dockerservice ${SUBSVC}"
-  "${DOCOCMD}" -f "${SUBCFG}" up -d --no-recreate --no-build --no-deps
+  "${DOCOCMD}" -f "${SUBCFG}" up -d ${DOCKER_COMPOSE_UP_ARGS}
   eend $?
 }
 


### PR DESCRIPTION
I thought about leaving `-d` always in the command and only allowing the rest
to be overridden, but in that case if you want to eliminate them you have to do
`DOCKER_COMPOSE_UP_ARGS=" "`; just using `""` causes the default to be used.
So I think it is better to make the user specify `-d` so that the string won't
be empty.