### PR TITLE
Add build subcommand and expose configtest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ The directory containing the service directories can be overridden by setting th
 Alternatively, the complete path to the docker-compose input file may be specified by setting SUBCFG in the services's `/etc/rc.conf.d` file.  The value of this variable is passed to the `-f` option of `docker-compose`.
 
 By default, the `docker-compose up` command is passed the arguments `-d --no-recreate --no-build --no-deps`.  `-d` is required because that's what puts the containers in the background, but the remaining arguments may be overridden by setting `DOCKER_COMPOSE_UP_ARGS`.
+
+dockerservice supplies two subcommands in addition to the openrc defaults:
+
+* configtest - verify that the configuration has no syntax errors
+* build - run docker-compose build.

--- a/dockerservice
+++ b/dockerservice
@@ -9,6 +9,12 @@ SUBSVC="${SVCNAME#*.}"
 DOCOCMD="/usr/bin/docker-compose"
 export COMPOSE_HTTP_TIMEOUT=300
 
+description="Manage docker services defined in ${SUBCFG}"
+extra_commands="configtest"
+extra_stopped_commands="build"
+description_configtest="Check configuration via \"docker-compose -f ${SUBCFG} config\""
+description_build="Run \"docker-compose -f ${SUBCFG} build\""
+
 depend() {
   need localmount net docker
   use dns
@@ -26,6 +32,13 @@ configtest() {
     eerror "config: error"
     return 1
   fi
+}
+
+build() {
+  configtest || return 1
+  ebegin "Building dockerservice ${SUBSVC}"
+  "${DOCOCMD}" -f "${SUBCFG}" build
+  eend $?
 }
 
 start() {
@@ -49,3 +62,4 @@ status() {
     return 3
   fi
 }
+

--- a/dockerservice
+++ b/dockerservice
@@ -10,8 +10,7 @@ DOCOCMD="/usr/bin/docker-compose"
 export COMPOSE_HTTP_TIMEOUT=300
 
 description="Manage docker services defined in ${SUBCFG}"
-extra_commands="configtest"
-extra_stopped_commands="build"
+extra_commands="configtest build"
 description_configtest="Check configuration via \"docker-compose -f ${SUBCFG} config\""
 description_build="Run \"docker-compose -f ${SUBCFG} build\""
 


### PR DESCRIPTION
I can't figure out how to get the new commands to appear in the
'--help' output, but they appear in the 'describe' subcommand output.

I'm not sure if build should actually be restricted to stopped mode.

I'm also not sure if you'll want this one, but I find it useful :)